### PR TITLE
Rewrite/pixel struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ SRC_PATH = src
 main: $(SRC_PATH)/*.c $(INCLUDES_PATH)/*.h
 	clang $(CFLAGS) -o bin/elp -I $(INCLUDES_PATH) -lm $(SRC_PATH)/*.c
 
+sane: $(SRC_PATH)/*.c $(INCLUDES_PATH)/*.h
+	clang $(CFLAGS) -fsanitize=address,undefined -o bin/elp -I $(INCLUDES_PATH) -lm $(SRC_PATH)/*.c
+
 PHONY: clean
 clean:
 	rm obj/*.o bin/elp

--- a/includes/f_manip.h
+++ b/includes/f_manip.h
@@ -24,5 +24,5 @@ void f_read(char* pathname, struct t_image* image);
  * Write a struct t_image* into a P6 formatted .ppm file.
  * Return 1 on success, 0 otherwise.
  */
-int f_write(char* pathname, struct t_image* image);
+int f_write(char* pathname, struct t_gsimage* image);
 #endif

--- a/includes/pixel.h
+++ b/includes/pixel.h
@@ -26,6 +26,18 @@ struct pixel {
     uint8_t b;
 };
 
+// Grayscale pixel format
+struct gspixel {
+    int gspx;
+};
+
+// Grayscale image format
+struct t_gsimage {
+    int h;
+    int w;
+    struct gspixel** im;
+};
+
 struct t_image {
     int h;
     int w;
@@ -40,17 +52,29 @@ struct pixel**
 new_px_array(const int h, const int w);
 
 /**
+ * Create new grayscale pixel array.
+ */
+struct gspixel**
+new_gspx_array(const int h, const int w);
+
+/**
  * Free memory for a 2D array of pixels (or a plate image)
  */
 void
 free_px_array(struct pixel** px_arr, const int h);
 
 /**
+ * Free memory for a 2D array of grayscale pixels
+ */
+void
+free_gspx_array(struct gspixel** px_arr, const int h);
+
+/**
  * Convert an image to a grayscale version. The grayscaled image is obtained
  * using grayscale coefficients.
  */
 void
-grayscale_filter(struct t_image* image);
+grayscale_filter(struct t_image* im_src, struct t_gsimage* im_dst);
 
 /**
  * Applies a 3x3 gaussian blur to an image. In this version, the outer edge
@@ -58,7 +82,7 @@ grayscale_filter(struct t_image* image);
  * is the gaussian blurred version of the image received as parameter.
  */
 void
-gaussian_blur3_filter(struct t_image* im_src, struct t_image* im_dst);
+gaussian_blur3_filter(struct t_gsimage* im_src, struct t_gsimage* im_dst);
 
 /**
  * Applies the sobel operator to an image. Outer edge pixels are ignored.

--- a/src/extract.c
+++ b/src/extract.c
@@ -5,15 +5,20 @@ char*
 extract_plate(struct t_image* image) {
 
     // Turn image to grayscale version
-    grayscale_filter(image);
-    f_write("screenshots/plgray.ppm", image);
+    struct t_gsimage gsimage;
+    grayscale_filter(image, &gsimage);
+    f_write("screenshots/plgray.ppm", &gsimage);
+    free_px_array(image->im, image->h);
 
     // Use gaussian blur on image
-    struct t_image gauss_image;
-    gaussian_blur3_filter(image, &gauss_image);
-    /*
+    struct t_gsimage gauss_image;
+    gaussian_blur3_filter(&gsimage, &gauss_image);
     f_write("screenshots/plgauss.ppm", &gauss_image);
 
+    free_gspx_array(gsimage.im, gsimage.h);
+    free_gspx_array(gauss_image.im, gauss_image.h);
+
+    /*
     // Use Sobel operator on image
     struct t_image sobel_image;
     sobel_filter(&gauss_image, &sobel_image);

--- a/src/extract.c
+++ b/src/extract.c
@@ -11,6 +11,7 @@ extract_plate(struct t_image* image) {
     // Use gaussian blur on image
     struct t_image gauss_image;
     gaussian_blur3_filter(image, &gauss_image);
+    /*
     f_write("screenshots/plgauss.ppm", &gauss_image);
 
     // Use Sobel operator on image
@@ -18,7 +19,6 @@ extract_plate(struct t_image* image) {
     sobel_filter(&gauss_image, &sobel_image);
     f_write("screenshots/plsobel.ppm", &sobel_image);
 
-    /*
     // Use simple thresholding
     struct t_image t_image;
     threshold(&gauss_image, &t_image);

--- a/src/f_manip.c
+++ b/src/f_manip.c
@@ -65,7 +65,7 @@ void f_read(char* pathname, struct t_image* image) {
     image->im = v1_plate;
 }
 
-int f_write(char* pathname, struct t_image* image) {
+int f_write(char* pathname, struct t_gsimage* image) {
     FILE* f = fopen(pathname, "wb");
     if (!f) {
 	perror("Failed to open file for writing: %s");
@@ -78,7 +78,9 @@ int f_write(char* pathname, struct t_image* image) {
     // Write the binary pixel data
     for (int i = 0; i < image->h; i++) {
 	for (int j = 0; j < image->w; j++) {
-	    fwrite(&(image->im[i][j]), sizeof(struct pixel), 1, f);
+	    fwrite(&(image->im[i][j]), 1, 1, f);
+	    fwrite(&(image->im[i][j]), 1, 1, f);
+	    fwrite(&(image->im[i][j]), 1, 1, f);
 	}
     }
 


### PR DESCRIPTION
Added a new structure type called t_gsimage. Grayscale image format, contains only one field of type int. Avoids typecasting in certain places.