### PR TITLE
Rewrite/gaussian_blur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ SRC_PATH = src
 main: $(SRC_PATH)/*.c $(INCLUDES_PATH)/*.h
 	clang $(CFLAGS) -o bin/elp -I $(INCLUDES_PATH) -lm $(SRC_PATH)/*.c
 
+sane: $(SRC_PATH)/*.c $(INCLUDES_PATH)/*.h
+	clang $(CFLAGS) -fsanitize=address,undefined -o bin/elp -I $(INCLUDES_PATH) -lm $(SRC_PATH)/*.c
+
 PHONY: clean
 clean:
 	rm obj/*.o bin/elp

--- a/includes/f_manip.h
+++ b/includes/f_manip.h
@@ -24,5 +24,5 @@ void f_read(char* pathname, struct t_image* image);
  * Write a struct t_image* into a P6 formatted .ppm file.
  * Return 1 on success, 0 otherwise.
  */
-int f_write(char* pathname, struct t_image* image);
+int f_write(char* pathname, struct t_gsimage* image);
 #endif

--- a/includes/pixel.h
+++ b/includes/pixel.h
@@ -26,6 +26,18 @@ struct pixel {
     uint8_t b;
 };
 
+// Grayscale pixel format
+struct gspixel {
+    int gspx;
+};
+
+// Grayscale image format
+struct t_gsimage {
+    int h;
+    int w;
+    struct gspixel** im;
+};
+
 struct t_image {
     int h;
     int w;
@@ -40,17 +52,29 @@ struct pixel**
 new_px_array(const int h, const int w);
 
 /**
+ * Create new grayscale pixel array.
+ */
+struct gspixel**
+new_gspx_array(const int h, const int w);
+
+/**
  * Free memory for a 2D array of pixels (or a plate image)
  */
 void
 free_px_array(struct pixel** px_arr, const int h);
 
 /**
+ * Free memory for a 2D array of grayscale pixels
+ */
+void
+free_gspx_array(struct gspixel** px_arr, const int h);
+
+/**
  * Convert an image to a grayscale version. The grayscaled image is obtained
  * using grayscale coefficients.
  */
 void
-grayscale_filter(struct t_image* image);
+grayscale_filter(struct t_image* im_src, struct t_gsimage* im_dst);
 
 /**
  * Applies a 3x3 gaussian blur to an image. In this version, the outer edge
@@ -58,7 +82,7 @@ grayscale_filter(struct t_image* image);
  * is the gaussian blurred version of the image received as parameter.
  */
 void
-gaussian_blur3_filter(struct t_image* im_src, struct t_image* im_dst);
+gaussian_blur3_filter(struct t_gsimage* im_src, struct t_gsimage* im_dst);
 
 /**
  * Applies the sobel operator to an image. Outer edge pixels are ignored.

--- a/src/extract.c
+++ b/src/extract.c
@@ -5,15 +5,20 @@ char*
 extract_plate(struct t_image* image) {
 
     // Turn image to grayscale version
-    grayscale_filter(image);
-    f_write("screenshots/plgray.ppm", image);
+    struct t_gsimage gsimage;
+    grayscale_filter(image, &gsimage);
+    f_write("screenshots/plgray.ppm", &gsimage);
+    free_px_array(image->im, image->h);
 
     // Use gaussian blur on image
-    struct t_image gauss_image;
-    gaussian_blur3_filter(image, &gauss_image);
-    /*
+    struct t_gsimage gauss_image;
+    gaussian_blur3_filter(&gsimage, &gauss_image);
     f_write("screenshots/plgauss.ppm", &gauss_image);
 
+    free_gspx_array(gsimage.im, gsimage.h);
+    free_gspx_array(gauss_image.im, gauss_image.h);
+
+    /*
     // Use Sobel operator on image
     struct t_image sobel_image;
     sobel_filter(&gauss_image, &sobel_image);

--- a/src/extract.c
+++ b/src/extract.c
@@ -11,6 +11,7 @@ extract_plate(struct t_image* image) {
     // Use gaussian blur on image
     struct t_image gauss_image;
     gaussian_blur3_filter(image, &gauss_image);
+    /*
     f_write("screenshots/plgauss.ppm", &gauss_image);
 
     // Use Sobel operator on image
@@ -18,7 +19,6 @@ extract_plate(struct t_image* image) {
     sobel_filter(&gauss_image, &sobel_image);
     f_write("screenshots/plsobel.ppm", &sobel_image);
 
-    /*
     // Use simple thresholding
     struct t_image t_image;
     threshold(&gauss_image, &t_image);

--- a/src/f_manip.c
+++ b/src/f_manip.c
@@ -65,7 +65,7 @@ void f_read(char* pathname, struct t_image* image) {
     image->im = v1_plate;
 }
 
-int f_write(char* pathname, struct t_image* image) {
+int f_write(char* pathname, struct t_gsimage* image) {
     FILE* f = fopen(pathname, "wb");
     if (!f) {
 	perror("Failed to open file for writing: %s");
@@ -78,7 +78,9 @@ int f_write(char* pathname, struct t_image* image) {
     // Write the binary pixel data
     for (int i = 0; i < image->h; i++) {
 	for (int j = 0; j < image->w; j++) {
-	    fwrite(&(image->im[i][j]), sizeof(struct pixel), 1, f);
+	    fwrite(&(image->im[i][j]), 1, 1, f);
+	    fwrite(&(image->im[i][j]), 1, 1, f);
+	    fwrite(&(image->im[i][j]), 1, 1, f);
 	}
     }
 

--- a/src/pixel.c
+++ b/src/pixel.c
@@ -187,8 +187,8 @@ gaussian_blur3_filter(struct t_gsimage* im_src, struct t_gsimage* im_dst) {
     im_dst->im = im_dst_im;
 
     // Second pass
-    for (int i = 0; i < im_dst->h - 1; i++) {
-	for (int j = 0; j < im_dst->w - 1; j++) {
+    for (int i = 0; i < im_dst->h; i++) {
+	for (int j = 0; j < im_dst->w; j++) {
 	    im_dst->im[i][j].gspx = GB3_FACTOR * (p1[i][j].gspx + 2 * p1[i][j + 1].gspx + p1[i][j + 2].gspx);
 	}
     }

--- a/src/pixel.c
+++ b/src/pixel.c
@@ -165,17 +165,29 @@ gaussian_blur3_filter(struct t_gsimage* im_src, struct t_gsimage* im_dst) {
 	i_arr[i][im_src->w + 1] = im_src->im[i - 1][im_src->w - 1];
     }
 
-    // Copy rest of picture
-    for (int i = 1; i < im_src->h + 1; i++)
-	for (int j = 1; j < im_src->w + 1; j++)
-	    i_arr[i][j] = im_src->im[i - 1][j - 1];
-
-    // First pass
+    // --- FIRST PASS --- //
+    // Vertical pass left-right border
     for (int i = 1; i < im_src->h + 1; i++) {
-	for (int j = 0; j < im_src->w + 2; j++) {
-	    p1[i - 1][j].gspx = i_arr[i - 1][j].gspx + 2 * i_arr[i][j].gspx + i_arr[i + 1][j].gspx;
+	p1[i - 1][0].gspx = i_arr[i - 1][0].gspx + 2 * i_arr[i][0].gspx + i_arr[i + 1][0].gspx;
+	p1[i - 1][im_src->w + 1].gspx = i_arr[i - 1][im_src->w + 1].gspx
+	    + 2 * i_arr[i][im_src->w + 1].gspx + i_arr[i + 1][im_src->w + 1].gspx;
+    }
+
+    // Pass upper-lower border
+    for (int j = 0; j < im_src->w; j++) {
+	p1[0][j + 1].gspx = i_arr[0][j + 1].gspx + 2 * im_src->im[0][j].gspx + im_src->im[1][j].gspx;
+	p1[im_src->h - 1][j + 1].gspx = im_src->im[im_src->h - 2][j].gspx
+	    + 2 * im_src->im[im_src->h - 1][j].gspx + i_arr[im_src->h + 1][j + 1].gspx;
+    }
+
+    // Pass middle of array
+    for (int i = 1; i < im_src->h - 1; i++) {
+	for (int j = 0; j < im_src->w; j++) {
+	    p1[i][j + 1].gspx = im_src->im[i - 1][j].gspx
+		+ 2 * im_src->im[i][j].gspx + im_src->im[i + 1][j].gspx;
 	}
     }
+    // --- END FIRST PASS --- //
 
     free_gspx_array(i_arr, im_src->h + 2);
     


### PR DESCRIPTION
Rewrite of the gaussian 3x3 blur. The function now blurs the image by padding the source image to reduce border artifacts and convolutes pixels with separated filters obtained from the initial gaussian kernel. The same logic could later be extended to convolute pixels with a bigger kernel without drastically affecting performance.